### PR TITLE
fix: skip `blockfrost-platform` timestamps in the shared logs

### DIFF
--- a/core/child-blockfrost-platform.go
+++ b/core/child-blockfrost-platform.go
@@ -5,10 +5,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"blockfrost.io/blockfrost-platform-desktop/constants"
 	"blockfrost.io/blockfrost-platform-desktop/ourpaths"
+
+	"github.com/acarl005/stripansi"
 )
 
 func childBlockfrostPlatform(syncProgressCh chan<- float64) func(SharedState, chan<- StatusAndUrl) ManagedChild {
@@ -17,6 +20,19 @@ func childBlockfrostPlatform(syncProgressCh chan<- float64) func(SharedState, ch
 
 		serviceName := "blockfrost-platform"
 		reSyncProgress := regexp.MustCompile(`"sync_progress"\s*:\s*(\d*\.\d+)`)
+
+		removeTimestamp := func(line string, when time.Time) string {
+			needle := when.Format("2006-01-02T15:04:05.")
+			index := strings.Index(line, needle)
+			if index != -1 {
+				end := index + len(needle) + 7
+				if end > len(line) {
+					end = len(line)
+				}
+				return line[:index] + line[end:]
+			}
+			return line
+		}
 
 		return ManagedChild{
 			ServiceName: serviceName,
@@ -71,8 +87,14 @@ func childBlockfrostPlatform(syncProgressCh chan<- float64) func(SharedState, ch
 					LastErr:     err,
 				}
 			},
-			LogMonitor:                        func(line string) {},
-			LogModifier:                       func(line string) string { return line },
+			LogMonitor: func(line string) {},
+			LogModifier: func(line string) string {
+				line = stripansi.Strip(line)
+				now := time.Now().UTC()
+				line = removeTimestamp(line, now)
+				line = removeTimestamp(line, now.Add(-1*time.Second))
+				return strings.TrimLeft(line, " ")
+			},
 			TerminateGracefullyByInheritedFd3: false,
 			ForceKillAfter:                    5 * time.Second,
 			PostStop:                          func() error { return nil },


### PR DESCRIPTION
## Context

We had duplicate timestamps before:

```
Mar 9 08:21:22.256Z blockfrost-platform[4161809]: 2026-03-09T08:21:22.256495Z  INFO JsonClient GET path="" url=http://127.0.0.1:35597/ pagination=None
```

After this change:

```
Mar 10 11:35:01.682Z blockfrost-platform[502668]: INFO JsonClient GET path="" url=http://127.0.0.1:46365/ pagination=None
Mar 10 11:35:01.682Z blockfrost-platform[502668]: INFO JsonClient GET path="health" url=http://127.0.0.1:46365/health pagination=None
```