### PR TITLE
chore: support `dolos bootstrap --continue` for interrupted Mithril restore

### DIFF
--- a/core/child-dolos.go
+++ b/core/child-dolos.go
@@ -20,7 +20,8 @@ import (
 type DolosPreRunState struct {
 	DolosWorkDir             string
 	ChainDir                 string
-	NeedsBootstrap           bool
+	MarkerPath               string
+	IsFreshBootstrap         bool
 	HasChainDir              bool
 	BootstrappingFromMithril bool
 }
@@ -31,18 +32,35 @@ func dolosPreRunState(shared SharedState) DolosPreRunState {
 	dolosWorkDir := ourpaths.WorkDir + sep + shared.Network + sep + "dolos"
 	chainDir := ourpaths.WorkDir + sep + shared.Network + sep + "chain"
 
+	// A marker file that exists only while a Mithril-based Dolos bootstrap is in
+	// progress. We create it before starting `dolos bootstrap mithril`, and only
+	// remove it once that finishes cleanly (exit 0). So if it’s still here on a
+	// later launch, the previous bootstrap was interrupted (app quit / crash) and
+	// we should resume it (`--continue`) rather than fall back to a very slow
+	// daemon-mode catch-up from a real `cardano-node`.
+	markerPath := ourpaths.DolosBootstrapMarkerPath(shared.Network)
+
+	// No Dolos data dir yet → this is a fresh bootstrap, not a resume of an
+	// interrupted one (which would have left partial data behind).
 	_, err := os.Stat(dolosWorkDir)
-	needsBootstrap := err != nil
+	isFreshBootstrap := err != nil
 
 	_, err = os.Stat(chainDir)
 	hasChainDir := err == nil
 
-	bootstrappingFromMithril := needsBootstrap && hasChainDir
+	_, err = os.Stat(markerPath)
+	mithrilBootstrapPreviouslyInterrupted := err == nil
+
+	// Bootstrap from the local `cardano-node` chain directory (probably a
+	// Mithril snapshot) when there’s no Dolos data yet, or when a prior such
+	// bootstrap was interrupted and must be resumed.
+	bootstrappingFromMithril := hasChainDir && (isFreshBootstrap || mithrilBootstrapPreviouslyInterrupted)
 
 	return DolosPreRunState{
 		DolosWorkDir:             dolosWorkDir,
 		ChainDir:                 chainDir,
-		NeedsBootstrap:           needsBootstrap,
+		MarkerPath:               markerPath,
+		IsFreshBootstrap:         isFreshBootstrap,
 		HasChainDir:              hasChainDir,
 		BootstrappingFromMithril: bootstrappingFromMithril,
 	}
@@ -106,11 +124,15 @@ func childDolos() func(SharedState, chan<- StatusAndUrl) ManagedChild {
 		// For log debouncing:
 		restoreProgressLastEmitted := time.Now()
 
+		// We use it in `PostStop` to see if a Mithril bootstrap got interrupted:
+		bootstrapExitCode := -1
+
 		return ManagedChild{
 			ServiceName: serviceName,
 			ExePath:     exePath,
 			Version:     constants.DolosVersion,
 			Revision:    constants.DolosRevision,
+			ExitCode:    &bootstrapExitCode,
 			MkArgv: func() ([]string, error) {
 				*shared.DolosPort = getFreeTCPPort()
 				templatePath := ourpaths.ResourcesDir + sep + "dolos-config" + sep + shared.Network + sep + "dolos.toml"
@@ -129,7 +151,7 @@ func childDolos() func(SharedState, chan<- StatusAndUrl) ManagedChild {
 				}
 				tempConfigPath = tmp
 
-				if prs.NeedsBootstrap {
+				if prs.BootstrappingFromMithril || prs.IsFreshBootstrap {
 					statusCh <- StatusAndUrl{
 						Status:      "bootstrapping",
 						Progress:    -1,
@@ -138,35 +160,48 @@ func childDolos() func(SharedState, chan<- StatusAndUrl) ManagedChild {
 						Url:         "",
 						OmitUrl:     false,
 					}
-
-					if prs.BootstrappingFromMithril {
-						return []string{
-							"--config", tempConfigPath,
-							"bootstrap", "mithril",
-							"--download-dir", prs.ChainDir,
-							"--skip-download",
-							"--retain-snapshot",
-							"--skip-validation",
-						}, nil
-						// After this long bootstrapping ends, everything will be restarted in `daemon` mode.
-					} else {
-						// But this setup returns immediately:
-						fmt.Printf("%s[%d]: running `dolos bootstrap relay`\n", serviceName, -1)
-						stdout, stderr, pid, err := runCommandWithTimeout(
-							exePath,
-							[]string{"--config", tempConfigPath, "bootstrap", "relay"},
-							[]string{},
-							60*time.Second,
-							nil,
-						)
-						if err != nil {
-							fmt.Printf("%s[%d]: failed: %v (stderr: %v) (stdout: %v)\n",
-								serviceName, pid, err, string(stdout), string(stderr))
-							return nil, err
-						}
-					}
 				}
 
+				if prs.BootstrappingFromMithril {
+					// Record that a Mithril-based bootstrap is underway. If we get
+					// interrupted (app quit / crash) before it finishes cleanly, this
+					// marker survives and makes the next launch resume it (see below)
+					// instead of falling back to a very slow daemon-mode catch-up.
+					if err := os.WriteFile(prs.MarkerPath,
+						[]byte("a `dolos bootstrap mithril` is in progress; "+
+							"if this file is still here, it was interrupted\n"),
+						0o644); err != nil {
+						fmt.Printf("%s[%d]: warning: could not write bootstrap marker %q: %v\n",
+							serviceName, -1, prs.MarkerPath, err)
+					}
+
+					argv := []string{
+						"--config", tempConfigPath,
+						"bootstrap", "mithril",
+						"--download-dir", prs.ChainDir,
+						"--skip-download",
+						"--retain-snapshot",
+						"--skip-validation",
+					}
+
+					// If Dolos data already exists, a previous bootstrap was interrupted,
+					// so resume it with `--continue` (without it, Dolos refuses to run on
+					// existing data). NB: resuming from a non-recoverable interruption
+					// point can still fail (a Dolos bug being fixed upstream,
+					// txpipe/dolos#1016); the user’s fallback is to re-trigger a full
+					// Mithril resync, which wipes this data and clears the marker.
+					if !prs.IsFreshBootstrap {
+						fmt.Printf("%s[%d]: resuming an interrupted Mithril bootstrap with `--continue`\n",
+							serviceName, -1)
+						argv = append(argv, "--continue")
+					}
+
+					return argv, nil
+					// After this long bootstrapping ends, everything will be restarted in `daemon` mode.
+				}
+
+				// Otherwise, just run the daemon which continues to sync via
+				// chain-sync off the local `cardano-node`).
 				return []string{
 					"--config", tempConfigPath,
 					"daemon",
@@ -294,6 +329,19 @@ func childDolos() func(SharedState, chan<- StatusAndUrl) ManagedChild {
 			PostStop: func() error {
 				if tempConfigPath != "" {
 					_ = os.Remove(tempConfigPath)
+				}
+				// A Mithril bootstrap that exited cleanly (0) is complete, so drop the
+				// marker and let the next launch go straight to daemon mode. Any other
+				// exit (non-zero, or killed → -1) means we were interrupted, so we keep
+				// the marker and resume with `--continue` on the next launch.
+				if prs.BootstrappingFromMithril && bootstrapExitCode == 0 {
+					if err := os.Remove(prs.MarkerPath); err != nil && !os.IsNotExist(err) {
+						fmt.Printf("%s[%d]: warning: could not remove bootstrap marker %q: %v\n",
+							serviceName, -1, prs.MarkerPath, err)
+					} else {
+						fmt.Printf("%s[%d]: Mithril bootstrap finished cleanly; cleared the resume marker\n",
+							serviceName, -1)
+					}
 				}
 				return nil
 			},

--- a/core/child-mithril.go
+++ b/core/child-mithril.go
@@ -382,6 +382,14 @@ func childMithril(appConfig appconfig.AppConfig) func(SharedState, chan<- Status
 					}
 				}
 
+				// We just wiped the Dolos data, so any leftover "bootstrap interrupted"
+				// marker is stale: drop it so the fresh bootstrap from this new snapshot
+				// doesn’t get treated as a resume (see child-dolos.go).
+				dolosBootstrapMarker := ourpaths.DolosBootstrapMarkerPath(shared.Network)
+				if err := os.Remove(dolosBootstrapMarker); err != nil && !os.IsNotExist(err) {
+					return err
+				}
+
 				currentStatus = SFinished
 				statusCh <- StatusAndUrl{
 					Status: currentStatus, Progress: -1,

--- a/core/child.go
+++ b/core/child.go
@@ -39,6 +39,11 @@ type ManagedChild struct {
 	OpenFileLimit                     int                 // if > 0, wrap child in a shell that sets RLIMIT_NOFILE to this value
 	ForceKillAfter                    time.Duration       // graceful exit timeout, after which we SIGKILL the child
 	PostStop                          func() error
+	// ExitCode, if non-nil, is set to the child process’s exit code (or -1 if
+	// it was killed / the code is unknown) right before the process’s output
+	// channel is closed, i.e. before PostStop runs. This lets a child tell a
+	// clean exit (0) apart from a crash or forced termination.
+	ExitCode *int
 }
 
 type StatusAndUrl struct {
@@ -311,7 +316,8 @@ func manageChildren(comm CommChannels_Manager, appConfig appconfig.AppConfig, mi
 					child.LogModifier, outputLines, terminateCh, &childPid,
 					child.TerminateGracefullyByInheritedFd3,
 					child.ForceKillAfter,
-					child.OpenFileLimit)
+					child.OpenFileLimit,
+					child.ExitCode)
 				defer func() {
 					if !childDidExit {
 						child.StatusCh <- StatusAndUrl{
@@ -436,7 +442,11 @@ func childProcess(
 	terminateGracefullyByInheritedFd3 bool,
 	gracefulExitTimeout time.Duration,
 	openFileLimit int,
+	exitCode *int, // if non-nil, set to the process’s exit code (-1 if unknown)
 ) {
+	if exitCode != nil {
+		*exitCode = -1
+	}
 	defer close(outputLines)
 
 	var terminationPipeReader *os.File
@@ -522,6 +532,9 @@ func childProcess(
 
 	go func() {
 		cmd.Wait()
+		if exitCode != nil && cmd.ProcessState != nil {
+			*exitCode = cmd.ProcessState.ExitCode()
+		}
 		wgOuts.Wait()
 		waitDone <- struct{}{}
 	}()
@@ -587,7 +600,11 @@ func childProcessPTY(
 	terminateGracefullyByInheritedFd3 bool,
 	gracefulExitTimeout time.Duration,
 	openFileLimit int,
+	exitCode *int, // if non-nil, set to the process’s exit code (-1 if unknown)
 ) {
+	if exitCode != nil {
+		*exitCode = -1
+	}
 	defer close(outputLines)
 
 	if terminateGracefullyByInheritedFd3 {
@@ -617,7 +634,17 @@ func childProcessPTY(
 		return
 	}
 	defer ptyFile.Close()
-	defer cmd.Wait()
+
+	// Reap the child and record its exit code (so PostStop can tell a clean exit
+	// from a crash). Deferred so it runs even if something below panics, and—being
+	// registered after `defer close(outputLines)`—it runs before that close, i.e.
+	// the code is set before PostStop sees the output channel end.
+	defer func() {
+		_ = cmd.Wait()
+		if exitCode != nil && cmd.ProcessState != nil {
+			*exitCode = cmd.ProcessState.ExitCode()
+		}
+	}()
 
 	waitDone := make(chan struct{})
 

--- a/core/child_unix.go
+++ b/core/child_unix.go
@@ -50,6 +50,7 @@ func childProcessPTYWindows(
 	terminateGracefullyByInheritedFd3 bool,
 	gracefulExitTimeout time.Duration,
 	openFileLimit int,
+	exitCode *int,
 ) {
 	panic("childProcessPTYWindows is only supported on Windows")
 }

--- a/core/child_windows.go
+++ b/core/child_windows.go
@@ -109,7 +109,11 @@ func childProcessPTYWindows(
 	terminateGracefullyByInheritedFd3 bool,
 	gracefulExitTimeout time.Duration,
 	openFileLimit int,
+	exitCode *int, // if non-nil, set to the process’s exit code (-1 if unknown)
 ) {
+	if exitCode != nil {
+		*exitCode = -1
+	}
 	defer close(outputLines)
 
 	if terminateGracefullyByInheritedFd3 {
@@ -151,9 +155,13 @@ func childProcessPTYWindows(
 
 	// XXX: cpty handles aren’t closed (they’re pipes) automatically when the command exits, so let’s do this:
 	go func() {
-		_, err := cpty.Wait(context.Background())
+		code, err := cpty.Wait(context.Background())
 		if err != nil {
 			outputLines <- fmt.Sprintf("fatal: error during cpty.Wait(): %v", err)
+		} else if exitCode != nil {
+			// Record the exit code before closing the cpty (which makes the
+			// reader goroutine signal waitDone → outputLines closes → PostStop):
+			*exitCode = int(code)
 		}
 		cpty.Close()
 	}()

--- a/core/ourpaths/ourpaths.go
+++ b/core/ourpaths/ourpaths.go
@@ -71,3 +71,8 @@ func init() {
 		ExeSuffix = ".exe"
 	}
 }
+
+func DolosBootstrapMarkerPath(network string) string {
+	sep := string(filepath.Separator)
+	return WorkDir + sep + network + sep + "dolos-bootstrap-incomplete"
+}

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1782212791,
-        "narHash": "sha256-V7g9QMqu2JEyz/j/S2qQDCzlnlhlONPCq6B7uq+8L8s=",
+        "lastModified": 1782220777,
+        "narHash": "sha256-xbcLA1kxvhBgbti6PRucCM0fo2ENcGbvyjMTTbBVocE=",
         "owner": "blockfrost",
         "repo": "blockfrost-platform",
-        "rev": "768e8e0ff8565bfa067a3bfb3b736fd2e6743c28",
+        "rev": "19cdcd1a0cf92effa414195c19a46e47f3ff7d70",
         "type": "github"
       },
       "original": {
@@ -188,16 +188,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1781915104,
-        "narHash": "sha256-IOD3rpyt0HNxapVxPn+xGwF3hMlQCLpBDbX+FzZtjmw=",
+        "lastModified": 1782215327,
+        "narHash": "sha256-tKhGe0eIiBR0H7fZS3/yOnEBxoAGJFVKxqIiNac9V3U=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "534158e2b7c7275fa1815816f4055842bca5abb6",
+        "rev": "ea7960a1c2e56c523fec7c4bab75f390ee443514",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.3.1",
+        "ref": "v1.3.2",
         "repo": "dolos",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1780080926,
-        "narHash": "sha256-WMmi1qorE6Rh98iA1KgWsPMEi3vA2V4G4l6/88uEdng=",
+        "lastModified": 1781783913,
+        "narHash": "sha256-7cmYYYEBoubfZxKeHsTkWyR/l7LFFVeIaxtJAYs7eOU=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "eaf48e749baa3d5e27d304107d8abf175fd756bb",
+        "rev": "776615bd369e17d3112d06b5647d4294f9ab952c",
         "type": "github"
       },
       "original": {
@@ -36,16 +36,16 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1781287584,
-        "narHash": "sha256-5S+IhJu2AS312aui3M4r05KvlmqRm9yl8/RI+BJDLrI=",
+        "lastModified": 1782212791,
+        "narHash": "sha256-V7g9QMqu2JEyz/j/S2qQDCzlnlhlONPCq6B7uq+8L8s=",
         "owner": "blockfrost",
         "repo": "blockfrost-platform",
-        "rev": "ff08d230ab69e429c3427b5e7b6745720740a2c8",
+        "rev": "768e8e0ff8565bfa067a3bfb3b736fd2e6743c28",
         "type": "github"
       },
       "original": {
         "owner": "blockfrost",
-        "ref": "pull/586/head",
+        "ref": "pull/594/head",
         "repo": "blockfrost-platform",
         "type": "github"
       }
@@ -53,11 +53,11 @@
     "blockfrost-tests": {
       "flake": false,
       "locked": {
-        "lastModified": 1780487747,
-        "narHash": "sha256-gewUt3uWqd2kNXgtepZIn7/pPkagFviyR9XI+8ZqIPI=",
+        "lastModified": 1781618927,
+        "narHash": "sha256-2FT9p9MmfKLuKUawKLKZyuWRAh0Xi4iA+sfc+ERjYrk=",
         "owner": "blockfrost",
         "repo": "blockfrost-tests",
-        "rev": "e1f3b728053e190a6e381761b3421a6c74ee6f78",
+        "rev": "f2e2845d390d8d271463ea93357eef6bf0617b4e",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1780099841,
-        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
+        "lastModified": 1781825982,
+        "narHash": "sha256-SlXKwIRIhrOSAcTjCB3ftPLzJWZStQIPS7J1FlZPnKk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
+        "rev": "469fd08d0bcf6926321fa973c6777fbc87785dd7",
         "type": "github"
       },
       "original": {
@@ -188,16 +188,16 @@
     "dolos": {
       "flake": false,
       "locked": {
-        "lastModified": 1780327931,
-        "narHash": "sha256-AqzgDeiUE3eHDWkedRJe51E+adTWOcTFHR4q7Mm5SDs=",
+        "lastModified": 1781915104,
+        "narHash": "sha256-IOD3rpyt0HNxapVxPn+xGwF3hMlQCLpBDbX+FzZtjmw=",
         "owner": "txpipe",
         "repo": "dolos",
-        "rev": "a92d1b3382931532682aa5c35ed0cca85383e5d4",
+        "rev": "534158e2b7c7275fa1815816f4055842bca5abb6",
         "type": "github"
       },
       "original": {
         "owner": "txpipe",
-        "ref": "v1.2.0",
+        "ref": "v1.3.1",
         "repo": "dolos",
         "type": "github"
       }
@@ -211,11 +211,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1780130272,
-        "narHash": "sha256-iCNBDsTLvD5pK9xCbd/Kl4NabrLRws6WVkiElGM9U1Q=",
+        "lastModified": 1781947848,
+        "narHash": "sha256-IergMRaafR+NBhWxgHuSRfsVKKnB7mSiYAsW728RYJM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "2118601eb824d47529307266d74e68dfd661c236",
+        "rev": "ab90d0629159f412313b6bde02bdc346bd9c8b3b",
         "type": "github"
       },
       "original": {
@@ -413,11 +413,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1781509190,
+        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1780060635,
-        "narHash": "sha256-k+iiE7EUc732hT7u1YP3omk9rCElKBbc5evooZSskwU=",
+        "lastModified": 1781933682,
+        "narHash": "sha256-ing9gva28bsg0g0dws5/gir/23NoyCX5wzvrRSQDI2I=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "5ebf65ce47fc047e8a2772297f2ddd988ab86c32",
+        "rev": "501826b6fb2b87d16fb35ffceb3b01f885517320",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,15 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1782220777,
+        "lastModified": 1782291208,
         "narHash": "sha256-xbcLA1kxvhBgbti6PRucCM0fo2ENcGbvyjMTTbBVocE=",
         "owner": "blockfrost",
         "repo": "blockfrost-platform",
-        "rev": "19cdcd1a0cf92effa414195c19a46e47f3ff7d70",
+        "rev": "4634d0eab5fce40e5dc20e6e8095cbc761b2358c",
         "type": "github"
       },
       "original": {
         "owner": "blockfrost",
-        "ref": "pull/594/head",
         "repo": "blockfrost-platform",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       flake = false; # we patch it & to prevent lockfile explosion
     };
     # FIXME: update to `main` when this is merged:
-    blockfrost-platform.url = "github:blockfrost/blockfrost-platform/pull/586/head";
+    blockfrost-platform.url = "github:blockfrost/blockfrost-platform/pull/594/head";
     ogmios = {
       url = "https://github.com/CardanoSolutions/ogmios.git";
       ref = "refs/tags/v6.11.2";

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       flake = false; # we patch it & to prevent lockfile explosion
     };
     # FIXME: update to `main` when this is merged:
-    blockfrost-platform.url = "github:blockfrost/blockfrost-platform/pull/594/head";
+    blockfrost-platform.url = "github:blockfrost/blockfrost-platform";
     ogmios = {
       url = "https://github.com/CardanoSolutions/ogmios.git";
       ref = "refs/tags/v6.11.2";

--- a/nix/devshells.nix
+++ b/nix/devshells.nix
@@ -48,6 +48,9 @@
         name = "staticcheck";
         package = pkgs.go-tools;
       }
+      {package = lib.hiPrio internal.common.dolos;}
+      {package = internal.mithril-client;}
+      {package = internal.blockfrost-platform;}
     ];
 
     language.c.compiler = pkgs.stdenv.cc;


### PR DESCRIPTION
## Context

Before this, Dolos restore when interrupted would end up in an undefined state.

- The simplest solution could be to remove some marker file when the restore is finished with a correct log message (or just a 0 exit code) from Dolos at the end. And if this file exists, start another Mithril restore on the next launch.

- See also [this Slack thread](https://input-output-rnd.slack.com/archives/C07UAU3PRFV/p1781698126606019?thread_ts=1781687321.265779&cid=C07UAU3PRFV).

- But `dolos bootstrap` also has a `--continue` flag! We can use it between app restarts if interrupted during Mithril bootstrap.

- :warning: But with `--continue`, it's possible that the bootstrap was interrupted at a non-recoverable point, see https://github.com/txpipe/dolos/pull/1016

Detected by @mchappell